### PR TITLE
Use new GitHub Action for GHDL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
 
   simulate:
     name: Simulate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Checkout
@@ -224,7 +224,7 @@ jobs:
           vunit-hdl@git+https://github.com/VUnit/vunit.git
 
     - name: Setup GHDL
-      uses: ghdl/setup-ghdl-ci@nightly
+      uses: paebbels/setup-ghdl@main
 
     - name: Clone dependency repos
       run: |


### PR DESCRIPTION
Replaces the old one which does not work on Ubuntu 24.04: https://github.com/ghdl/ghdl/issues/2852

Note that this action will be moved from the "paebbels" to the "ghdl" namespace in the future.

We should also use a tag instead of "main", when available.